### PR TITLE
The Dockering

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.idea
+devenv
+.gitignore
+.gitmodules
+bin
+obj

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,15 @@
+name: Docker Image CI
+on:
+  push:
+    branches: [ v2 ]
+  pull_request:
+    branches: [ v2 ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag xlws:$(date +%s)

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,9 +1,9 @@
 name: Docker Image CI
 on:
   push:
-    branches: [ v2 ]
+    branches: [ master ]
   pull_request:
-    branches: [ v2 ]
+    branches: [ master ]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,52 @@
+name: Docker Publish
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  release:
+    types:
+      - created
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -396,6 +396,7 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+.idea
 
 launchSettings.json
 appsettings.Development.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# https://hub.docker.com/_/microsoft-dotnet
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+WORKDIR /source
+
+COPY . .
+RUN dotnet restore
+
+WORKDIR /source/XLWebServices
+RUN dotnet publish -c release -o /app --no-restore
+
+# final stage/image
+FROM mcr.microsoft.com/dotnet/aspnet:7.0
+WORKDIR /app
+COPY --from=build /app ./
+ENTRYPOINT ["dotnet", "XLWebServices.dll"]

--- a/devenv/docker-compose.yml
+++ b/devenv/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3.9"
+services:
+  redis:
+    image: "redis:7.0.8"
+    command: 'redis-server --save "" --loglevel warning'
+    ports:
+      - "6379:6379"


### PR DESCRIPTION
* All changes are run through `docker build` CI
* Tagging a new release triggers a deployment to `ghcr.io/goatcorp/xlwebservices` tagged with the appropriate version number
* The Compose file in `devenv` can be used to spin up a Redis server for development

Mount anything you need as a volume; the application folder is `/app`, so `appsettings.json` probably needs to get mounted there. Redis needs to either be on the same Docker network with the connection string set accordingly, or this needs to be run in host networking mode.

I opted against better build caching because Octokit complicates that a bit, but that can be improved later.