### PR TITLE
Implement Endorsement Count for Plugins

### DIFF
--- a/XLWebServices/Controllers/PluginController.cs
+++ b/XLWebServices/Controllers/PluginController.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.Json;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 using Prometheus;
 using XLWebServices.Data;
@@ -84,6 +85,7 @@ public class PluginController : ControllerBase
     }
 
     [HttpPost("{internalName}")]
+    [EnableRateLimiting("limitip")]
     public async Task<IActionResult> Endorse(string internalName) {
         if (this.redis.HasFailed && this.pluginData.Get()?.PluginMaster == null)
             return StatusCode(500, "Precondition failed");

--- a/XLWebServices/Services/PluginData/PluginDataService.cs
+++ b/XLWebServices/Services/PluginData/PluginDataService.cs
@@ -111,10 +111,11 @@ public class PluginDataService
 
                 if (!_redis.HasFailed)
                 {
-                    var dlCount = await _redis.RunFallibleAsync(s => s.GetCount(manifest.InternalName));
-                    if (dlCount.HasValue)
+                    var result = await _redis.RunFallibleAsync(async s => (await s.GetCount(manifest.InternalName), await s.GetEndCount(manifest.InternalName)));
+                    if (result is var (dlCount, endCount))
                     {
-                        manifest.DownloadCount = dlCount.Value;
+                        manifest.DownloadCount = dlCount;
+                        manifest.EndorsementCount = endCount;
                     }
                 }
                 
@@ -143,10 +144,11 @@ public class PluginDataService
 
                 if (!_redis.HasFailed)
                 {
-                    var dlCount = await _redis.RunFallibleAsync(s => s.GetCount(manifest.InternalName));
-                    if (dlCount.HasValue)
+                    var result = await _redis.RunFallibleAsync(async s => (await s.GetCount(manifest.InternalName), await s.GetEndCount(manifest.InternalName)));
+                    if (result is var (dlCount, endCount))
                     {
-                        manifest.DownloadCount = dlCount.Value;
+                        manifest.DownloadCount = dlCount;
+                        manifest.EndorsementCount = endCount;
                     }
                 }
 
@@ -229,10 +231,11 @@ public class PluginDataService
                 
                 if (!_redis.HasFailed)
                 {
-                    var dlCount = await _redis.RunFallibleAsync(s => s.GetCount(manifest.InternalName));
-                    if (dlCount.HasValue)
+                    var result = await _redis.RunFallibleAsync(async s => (await s.GetCount(manifest.InternalName), await s.GetEndCount(manifest.InternalName)));
+                    if (result is var (dlCount, endCount))
                     {
-                        manifest.DownloadCount = dlCount.Value;
+                        manifest.DownloadCount = dlCount;
+                        manifest.EndorsementCount = endCount;
                     }
                 }
 

--- a/XLWebServices/Services/PluginData/PluginManifest.cs
+++ b/XLWebServices/Services/PluginData/PluginManifest.cs
@@ -24,6 +24,7 @@ public class PluginManifest
         this.ApplicableVersion = toCopy.ApplicableVersion;
         this.DalamudApiLevel = toCopy.DalamudApiLevel;
         this.DownloadCount = toCopy.DownloadCount;
+        this.EndorsementCount = toCopy.EndorsementCount;
         this.LastUpdate = toCopy.LastUpdate;
         this.DownloadLinkInstall = toCopy.DownloadLinkInstall;
         this.DownloadLinkUpdate = toCopy.DownloadLinkUpdate;
@@ -147,6 +148,12 @@ public class PluginManifest
     /// </summary>
     [JsonPropertyName("DownloadCount")]
     public long DownloadCount { get; set; }
+
+    /// <summary>
+    ///     Gets the number of endorsements this plugin has.
+    /// </summary>
+    [JsonPropertyName("EndorsementCount")]
+    public long EndorsementCount { get; set; }
 
     /// <summary>
     ///     Gets the last time this plugin was updated.

--- a/XLWebServices/Services/RedisService.cs
+++ b/XLWebServices/Services/RedisService.cs
@@ -8,6 +8,7 @@ public class RedisService
     public IDatabase Database;
 
     private const string RedisCountPrefix = "PC1-";
+    private const string RedisEndCountPrefix = "PEC1-";
     private const string RedisPrPrefix = "PPR1-";
 
     public RedisService(ILogger<RedisService> logger, IConfiguration configuration)
@@ -44,6 +45,24 @@ public class RedisService
     public async Task<long> GetCount(string internalName)
     {
         var value = await this.Database.StringGetAsync(RedisCountPrefix + internalName);
+
+        if (value.IsNullOrEmpty)
+        {
+            return 0;
+        }
+
+        value.TryParse(out long result);
+        return result;
+    }
+
+    public async Task<long> IncrementEndCount(string internalName)
+    {
+        return await this.Database.StringIncrementAsync(RedisEndCountPrefix + internalName);
+    }
+
+    public async Task<long> GetEndCount(string internalName)
+    {
+        var value = await this.Database.StringGetAsync(RedisEndCountPrefix + internalName);
 
         if (value.IsNullOrEmpty)
         {


### PR DESCRIPTION
As suggested on Discord, I'd like to add a simple endorsements system to Dalamud to positively reinforce plugin development and enable users to leave positive feedback without having to write a message through the "Leave Feedback" system.

Included in this PR:
- Endorsement Count is included in the PluginMaster
- New POST action to increment endorsement count for a plugin
- Rate limiting to 10 requests per minute per IP per XLWebServices server

Relevant pull requests:
- Client Side https://github.com/goatcorp/Dalamud/pull/1403
- Translations https://github.com/goatcorp/DalamudAssets/pull/154